### PR TITLE
Default zoom

### DIFF
--- a/ModelViewer/ModelViewer/ModelLoader.cpp
+++ b/ModelViewer/ModelViewer/ModelLoader.cpp
@@ -14,7 +14,7 @@ Model ModelLoader::LoadModel(const QString& file)
 	// And have it read the given file with some example postprocessing
 	// Usually - if speed is not the most important aspect for you - you'll
 	// probably to request more postprocessing than we do in this example.
-	const aiScene* pScene = importer.ReadFile(file.toStdString(), aiProcess_Triangulate | aiProcess_JoinIdenticalVertices | aiProcess_SortByPType);
+	const aiScene* pScene = importer.ReadFile(file.toStdString(), aiProcessPreset_TargetRealtime_Quality ^ aiProcess_GenSmoothNormals | aiProcess_GenNormals | aiProcess_GenBoundingBoxes);
 	
 	// If the import failed, report it
 	if (!pScene) {
@@ -161,10 +161,19 @@ Model ModelLoader::ProcessModel(aiScene const* pObject)
 		newMesh.m_indexBuffer.write(0, indices.data(), indexBufferSize);
 
 
+		// Load axis aligned bounding box (AABB)
+		newMesh.m_AABBMin.setX(pMesh->mAABB.mMin.x);
+		newMesh.m_AABBMin.setY(pMesh->mAABB.mMin.y);
+		newMesh.m_AABBMin.setZ(pMesh->mAABB.mMin.z);
+		newMesh.m_AABBMax.setX(pMesh->mAABB.mMax.x);
+		newMesh.m_AABBMax.setY(pMesh->mAABB.mMax.y);
+		newMesh.m_AABBMax.setZ(pMesh->mAABB.mMax.z);
+
+
 		// Append this mesh to the list
 		ret.m_meshes.push_back(newMesh);
 	}
 
-	ret.m_isValid = true;
+	ret.Finalize();
 	return ret;
 }

--- a/ModelViewer/ModelViewer/ModelLoader.h
+++ b/ModelViewer/ModelViewer/ModelLoader.h
@@ -3,6 +3,7 @@
 
 #include <QString>
 #include <QOpenGLBuffer>
+#include <QVector3D>
 
 struct aiScene;
 
@@ -34,11 +35,39 @@ struct Mesh {
 	bool m_hasNormals;
 	bool m_hasUVCoordinates;
 	bool m_hasColors;
+
+	// Define 2 points, the min and max of the axis aligned bounding box
+	QVector3D m_AABBMin;
+	QVector3D m_AABBMax;
 };
 
 struct Model {
 	bool m_isValid = false;
 	std::vector<Mesh> m_meshes;
+
+	// Define 2 points, the min and max of the axis aligned bounding box
+	QVector3D m_AABBMin;
+	QVector3D m_AABBMax;
+
+	void Finalize() {
+		// Compute the AABB for the entire model
+		m_AABBMin = { FLT_MAX, FLT_MAX, FLT_MAX };
+		m_AABBMax = { FLT_MIN, FLT_MIN, FLT_MIN };
+
+		for (auto& it : m_meshes) {
+			m_AABBMin[0] = std::min(m_AABBMin[0], it.m_AABBMin[0]);
+			m_AABBMin[1] = std::min(m_AABBMin[1], it.m_AABBMin[1]);
+			m_AABBMin[2] = std::min(m_AABBMin[2], it.m_AABBMin[2]);
+			m_AABBMax[0] = std::max(m_AABBMax[0], it.m_AABBMax[0]);
+			m_AABBMax[1] = std::max(m_AABBMax[1], it.m_AABBMax[1]);
+			m_AABBMax[2] = std::max(m_AABBMax[2], it.m_AABBMax[2]);
+		}
+
+		// Set the model as valid if there is at least one mesh
+		if (m_meshes.size() > 0) {
+			m_isValid = true;
+		}
+	}
 };
 
 class ModelLoader

--- a/ModelViewer/ModelViewerTest/test.cpp
+++ b/ModelViewer/ModelViewerTest/test.cpp
@@ -32,6 +32,7 @@ private slots:
 	void panWithMouse();
 	void checkMousePressAndRelease();
 	void zoomWithMouse();
+	void defaultZoom();
 
 private:
 	ModelViewer* m_pWindow = nullptr;
@@ -240,7 +241,7 @@ void ModelViewerTest::resetView()
 
 	// Check that we start w/ an idenity matrix
 	m_pWindow->GetGraphicsWindow()->resetView();
-	QVERIFY(m_pWindow->GetGraphicsWindow()->GetModelMatrix() == resetMatrix);
+	resetMatrix = m_pWindow->GetGraphicsWindow()->GetModelMatrix();
 
 	// Check that after altering it we end w/ an idenity matrix
 	QTest::mousePress(m_pWindow->GetGraphicsWindow(), Qt::RightButton);
@@ -258,7 +259,7 @@ void ModelViewerTest::rotateWithMouse()
 {
 	m_pWindow->show();
 	m_pWindow->GetGraphicsWindow()->resetView();
-	QVERIFY(m_pWindow->GetGraphicsWindow()->GetModelMatrix() == resetMatrix);
+	resetMatrix = m_pWindow->GetGraphicsWindow()->GetModelMatrix();
 
 	// Test rotating
 	QTest::mousePress(m_pWindow->GetGraphicsWindow(), Qt::LeftButton);
@@ -274,7 +275,7 @@ void ModelViewerTest::panWithMouse()
 {
 	m_pWindow->show();
 	m_pWindow->GetGraphicsWindow()->resetView();
-	QVERIFY(m_pWindow->GetGraphicsWindow()->GetModelMatrix() == resetMatrix);
+	resetMatrix = m_pWindow->GetGraphicsWindow()->GetModelMatrix();
 
 	// Test Pan
 	QTest::mousePress(m_pWindow->GetGraphicsWindow(), Qt::RightButton);
@@ -292,7 +293,7 @@ void ModelViewerTest::checkMousePressAndRelease()// FIXME: The mouse inputs are 
 {
 	m_pWindow->show();
 	m_pWindow->GetGraphicsWindow()->resetView();
-	QVERIFY(m_pWindow->GetGraphicsWindow()->GetModelMatrix() == resetMatrix);
+	resetMatrix = m_pWindow->GetGraphicsWindow()->GetModelMatrix();
 
 	// Test right click
 	QTest::mousePress(m_pWindow->GetGraphicsWindow(), Qt::RightButton);
@@ -312,13 +313,29 @@ void ModelViewerTest::zoomWithMouse()
 {
 	m_pWindow->show();
 	m_pWindow->GetGraphicsWindow()->resetView();
-	QVERIFY(m_pWindow->GetGraphicsWindow()->GetModelMatrix() == resetMatrix);
+	resetMatrix = m_pWindow->GetGraphicsWindow()->GetModelMatrix();
 
 	//https://stackoverflow.com/questions/50996997/how-to-simulate-mouse-wheel-events-using-qtestlib-qt5
 	ViewerGraphicsWindow* test = m_pWindow->GetGraphicsWindow();
 	test->SetScale(.5 * test->zoomSensitivity);
 	QVERIFY(test->GetModelMatrix() != resetMatrix);
 }
+
+void ModelViewerTest::defaultZoom()
+{
+	m_pWindow->show();
+	m_pWindow->GetGraphicsWindow()->resetView();
+	resetMatrix = m_pWindow->GetGraphicsWindow()->GetModelMatrix();
+
+	// Load a different model
+	bool success = m_pWindow->GetGraphicsWindow()->loadModel("../Data/Models/cubeColor.ply");
+	QVERIFY(success);
+	
+	// Check that the scene was resized to show this model
+	ViewerGraphicsWindow* test = m_pWindow->GetGraphicsWindow();
+	QVERIFY(test->GetModelMatrix() != resetMatrix);
+}
+
 
 
 QTEST_MAIN(ModelViewerTest)

--- a/ModelViewer/ModelViewerTest/test.cpp
+++ b/ModelViewer/ModelViewerTest/test.cpp
@@ -35,6 +35,10 @@ private slots:
 	void defaultZoom();
 
 private:
+	// Helpers
+	void ResetViewAndShow();
+
+
 	ModelViewer* m_pWindow = nullptr;
 	QMatrix4x4 resetMatrix;
 };
@@ -65,6 +69,14 @@ void ModelViewerTest::cleanup()
 	// Called after each test case
 }
 
+
+// Helpers
+void ModelViewerTest::ResetViewAndShow()
+{
+	m_pWindow->show();
+	m_pWindow->GetGraphicsWindow()->resetView();
+	resetMatrix = m_pWindow->GetGraphicsWindow()->GetModelMatrix();
+}
 
 
 void ModelViewerTest::integration()
@@ -237,11 +249,7 @@ void ModelViewerTest::displayModel()
 
 void ModelViewerTest::resetView()
 {
-	m_pWindow->show();
-
-	// Check that we start w/ an idenity matrix
-	m_pWindow->GetGraphicsWindow()->resetView();
-	resetMatrix = m_pWindow->GetGraphicsWindow()->GetModelMatrix();
+	ResetViewAndShow();
 
 	// Check that after altering it we end w/ an idenity matrix
 	QTest::mousePress(m_pWindow->GetGraphicsWindow(), Qt::RightButton);
@@ -257,9 +265,7 @@ void ModelViewerTest::resetView()
 
 void ModelViewerTest::rotateWithMouse()
 {
-	m_pWindow->show();
-	m_pWindow->GetGraphicsWindow()->resetView();
-	resetMatrix = m_pWindow->GetGraphicsWindow()->GetModelMatrix();
+	ResetViewAndShow();
 
 	// Test rotating
 	QTest::mousePress(m_pWindow->GetGraphicsWindow(), Qt::LeftButton);
@@ -273,9 +279,7 @@ void ModelViewerTest::rotateWithMouse()
 
 void ModelViewerTest::panWithMouse()
 {
-	m_pWindow->show();
-	m_pWindow->GetGraphicsWindow()->resetView();
-	resetMatrix = m_pWindow->GetGraphicsWindow()->GetModelMatrix();
+	ResetViewAndShow();
 
 	// Test Pan
 	QTest::mousePress(m_pWindow->GetGraphicsWindow(), Qt::RightButton);
@@ -289,11 +293,9 @@ void ModelViewerTest::panWithMouse()
 	m_pWindow->hide();
 }
 
-void ModelViewerTest::checkMousePressAndRelease()// FIXME: The mouse inputs are not working...
+void ModelViewerTest::checkMousePressAndRelease()
 {
-	m_pWindow->show();
-	m_pWindow->GetGraphicsWindow()->resetView();
-	resetMatrix = m_pWindow->GetGraphicsWindow()->GetModelMatrix();
+	ResetViewAndShow();
 
 	// Test right click
 	QTest::mousePress(m_pWindow->GetGraphicsWindow(), Qt::RightButton);
@@ -311,9 +313,7 @@ void ModelViewerTest::checkMousePressAndRelease()// FIXME: The mouse inputs are 
 
 void ModelViewerTest::zoomWithMouse()
 {
-	m_pWindow->show();
-	m_pWindow->GetGraphicsWindow()->resetView();
-	resetMatrix = m_pWindow->GetGraphicsWindow()->GetModelMatrix();
+	ResetViewAndShow();
 
 	//https://stackoverflow.com/questions/50996997/how-to-simulate-mouse-wheel-events-using-qtestlib-qt5
 	ViewerGraphicsWindow* test = m_pWindow->GetGraphicsWindow();
@@ -323,9 +323,7 @@ void ModelViewerTest::zoomWithMouse()
 
 void ModelViewerTest::defaultZoom()
 {
-	m_pWindow->show();
-	m_pWindow->GetGraphicsWindow()->resetView();
-	resetMatrix = m_pWindow->GetGraphicsWindow()->GetModelMatrix();
+	ResetViewAndShow();
 
 	// Load a different model
 	bool success = m_pWindow->GetGraphicsWindow()->loadModel("../Data/Models/cubeColor.ply");


### PR DESCRIPTION
closes #26 

- Changed the assimp post processing steps to generate normals AND generate bounding boxes
- Computed an overall bounding box for each model
- Upon resetView(), automatically zoom so the whole model can be viewed
- Added a unit test